### PR TITLE
Sanitize notebook cell numbers, update HiSeqV2

### DIFF
--- a/2.TCGA-process.ipynb
+++ b/2.TCGA-process.ipynb
@@ -352,7 +352,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 7,
    "metadata": {
     "collapsed": true
    },
@@ -374,7 +374,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 8,
    "metadata": {
     "collapsed": false
    },
@@ -385,7 +385,7 @@
        "{\"3'UTR\", \"5'Flank\", \"5'UTR\", 'IGR', 'Intron', 'Silent'}"
       ]
      },
-     "execution_count": 11,
+     "execution_count": 8,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -397,7 +397,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 9,
    "metadata": {
     "collapsed": false
    },
@@ -441,7 +441,7 @@
        "1  TCGA-02-0003-01  chr10  TACC2      1"
       ]
      },
-     "execution_count": 12,
+     "execution_count": 9,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -467,7 +467,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 10,
    "metadata": {
     "collapsed": false
    },
@@ -508,7 +508,7 @@
        "1          2  chr12    A2M"
       ]
      },
-     "execution_count": 13,
+     "execution_count": 10,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -522,7 +522,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 11,
    "metadata": {
     "collapsed": false
    },
@@ -572,7 +572,7 @@
        "1  TCGA-17-Z015-01  chr1  TPM3      1       7170   TPM3"
       ]
      },
-     "execution_count": 14,
+     "execution_count": 11,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -587,7 +587,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 12,
    "metadata": {
     "collapsed": false
    },
@@ -598,7 +598,7 @@
        "(8507, 21940)"
       ]
      },
-     "execution_count": 15,
+     "execution_count": 12,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -615,7 +615,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 13,
    "metadata": {
     "collapsed": false
    },
@@ -626,7 +626,7 @@
        "'0.67% sample-gene pairs are mutated'"
       ]
      },
-     "execution_count": 16,
+     "execution_count": 13,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -638,7 +638,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 14,
    "metadata": {
     "collapsed": false
    },
@@ -694,7 +694,7 @@
        "4   CSMD3   989"
       ]
      },
-     "execution_count": 17,
+     "execution_count": 14,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -706,7 +706,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 15,
    "metadata": {
     "collapsed": false
    },
@@ -762,7 +762,7 @@
        "4  TCGA-B5-A0JY-01       6151"
       ]
      },
-     "execution_count": 18,
+     "execution_count": 15,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -783,7 +783,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 16,
    "metadata": {
     "collapsed": false
    },
@@ -796,7 +796,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 17,
    "metadata": {
     "collapsed": false
    },
@@ -807,7 +807,7 @@
        "set()"
       ]
      },
-     "execution_count": 20,
+     "execution_count": 17,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -825,7 +825,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": 18,
    "metadata": {
     "collapsed": false
    },
@@ -836,7 +836,7 @@
        "(10459, 20530)"
       ]
      },
-     "execution_count": 21,
+     "execution_count": 18,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -860,7 +860,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": 19,
    "metadata": {
     "collapsed": false
    },
@@ -943,7 +943,7 @@
        "TCGA-02-2486-01  6.7716  15.3224  6.3377  2.2199  16.7832"
       ]
      },
-     "execution_count": 22,
+     "execution_count": 19,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -964,7 +964,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": 20,
    "metadata": {
     "collapsed": false
    },
@@ -975,7 +975,7 @@
        "7705"
       ]
      },
-     "execution_count": 23,
+     "execution_count": 20,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -987,7 +987,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": 21,
    "metadata": {
     "collapsed": false
    },
@@ -1009,7 +1009,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": 22,
    "metadata": {
     "collapsed": false
    },
@@ -1031,7 +1031,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": 23,
    "metadata": {
     "collapsed": false
    },
@@ -1053,7 +1053,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 24,
    "metadata": {
     "collapsed": true
    },

--- a/download/HiSeqV2.json
+++ b/download/HiSeqV2.json
@@ -14,7 +14,7 @@
  "label":"gene expression",
  "cohort":"TCGA Pan-Cancer (PANCAN)",
  "redistribution":true,
- "version":"2016-04-29",
+ "version":"2016-08-16",
  "tags":
  ["cancer", "non-small cell lung cancer", "gastric cancer",
   "pancancer", "Adrenal gland", "Esophagus", "Rectum", "Endometrium",

--- a/scripts/2.TCGA-process.py
+++ b/scripts/2.TCGA-process.py
@@ -63,7 +63,7 @@ snp_mutation_df.effect.value_counts().reset_index()
 # 
 # The next cell specifies which mutations to preserve as gene-affecting, which were chosen according to the red & blue [mutation effects in Xena](http://xena.ucsc.edu/how-we-characterize-mutations/).
 
-# In[10]:
+# In[7]:
 
 mutations = {
     'Frame_Shift_Del',
@@ -79,13 +79,13 @@ mutations = {
 }
 
 
-# In[11]:
+# In[8]:
 
 # Mutations effects that were observed but nut included
 set(snp_mutation_df.effect.unique()) - mutations
 
 
-# In[12]:
+# In[9]:
 
 gene_mutation_df = (snp_mutation_df
     .query("effect in @mutations")
@@ -100,7 +100,7 @@ gene_mutation_df.head(2)
 
 # Next, map combination of chromosome/gene symbol to Entrez ID
 
-# In[13]:
+# In[10]:
 
 # Retrieve chr/gene symbol to entrez_id mapping
 path = os.path.join('mapping', 'PANCAN-mutation', 'PANCAN-mutation-gene-map.tsv')
@@ -108,7 +108,7 @@ mutation_map_df = pandas.read_table(path)
 mutation_map_df.head(2)
 
 
-# In[14]:
+# In[11]:
 
 # merge with mapping df to yield column with entrez_id
 # inner join will drop mutations that are not mapped
@@ -117,7 +117,7 @@ gene_mutation_df = pandas.merge(gene_mutation_df, mutation_map_df, left_on = ['c
 gene_mutation_df.head(2)
 
 
-# In[15]:
+# In[12]:
 
 # Create a sample (rows) by gene (columns) matrix of mutation status
 
@@ -128,19 +128,19 @@ gene_mutation_mat_df = (gene_mutation_df
 gene_mutation_mat_df.shape
 
 
-# In[16]:
+# In[13]:
 
 '{:.2%} sample-gene pairs are mutated'.format(
     gene_mutation_mat_df.stack().mean())
 
 
-# In[17]:
+# In[14]:
 
 # Top mutated genes
 gene_mutation_df.gene.value_counts().reset_index().head(5)
 
 
-# In[18]:
+# In[15]:
 
 # Top mutated samples
 gene_mutation_df.sample_id.value_counts().reset_index().head(5)
@@ -150,14 +150,14 @@ gene_mutation_df.sample_id.value_counts().reset_index().head(5)
 # 
 # This file contains gene expression data from RNA-Sequencing. See the [online documentation](https://genome-cancer.soe.ucsc.edu/proj/site/xena/datapages/?dataset=TCGA.PANCAN.sampleMap/HiSeqV2&host=https://tcga.xenahubs.net) for `HiSeqV2`.
 
-# In[19]:
+# In[16]:
 
 # Read the gene × sample dataset
 path = os.path.join('download', 'HiSeqV2.tsv.bz2')
 expr_df = pandas.read_table(path, index_col=0)
 
 
-# In[20]:
+# In[17]:
 
 # Retrieve symbol to gene mapping for HiSeqV2
 path = os.path.join('mapping', 'HiSeqV2-genes', 'HiSeqV2-gene-map.tsv')
@@ -169,7 +169,7 @@ unmapped_symbols = set(expr_df.index) - set(symbol_to_entrez)
 unmapped_symbols
 
 
-# In[21]:
+# In[18]:
 
 # Process the dataset
 expr_df = (expr_df
@@ -187,7 +187,7 @@ expr_df.index.rename('sample_id', inplace=True)
 expr_df.shape
 
 
-# In[22]:
+# In[19]:
 
 # Peak at the data matrix
 expr_df.iloc[:5, :5]
@@ -197,13 +197,13 @@ expr_df.iloc[:5, :5]
 # 
 # Find samples with both mutation and expression data. We assume that if a sample was not in `PANCAN_mutation`, it was not assayed for mutation. Hence, zero-mutation cancers are excluded even if they have mutation data.
 
-# In[23]:
+# In[20]:
 
 sample_ids = list(gene_mutation_mat_df.index & expr_df.index)
 len(sample_ids)
 
 
-# In[24]:
+# In[21]:
 
 # Filter expression (x) and mutation (y) matrices for common samples
 x_df = expr_df.loc[sample_ids, :]
@@ -214,7 +214,7 @@ y_df = gene_mutation_mat_df.loc[sample_ids, :]
 # 
 # Matrices are saved as sample × gene TSVs. Subsetted matrices are also exported to allow users to quickly explore small portions of the dataset.
 
-# In[25]:
+# In[22]:
 
 def sample_df(df, nrows=None, ncols=None, row_seed=0, col_seed=0):
     """Randomly subset a dataframe, preserving row and column order."""
@@ -230,7 +230,7 @@ def sample_df(df, nrows=None, ncols=None, row_seed=0, col_seed=0):
     )
 
 
-# In[ ]:
+# In[23]:
 
 tsv_args = {'sep': '\t', 'float_format': '%.3g'}
 
@@ -246,7 +246,7 @@ for df, name in (x_df, 'expression-matrix'), (y_df, 'mutation-matrix'):
         sample_df(df, nrows=nrows, ncols=ncols).to_csv(path, **tsv_args)
 
 
-# In[ ]:
+# In[24]:
 
 
 


### PR DESCRIPTION
The version (date) of the Xena Browser `HiSeqV2` file updated, but doesn't show any visible downstream changes.

Ran `bash execute.sh` which refreshed some cell numbers that had become dirty.

Uploaded full datasets to figshare. See the following version-specific URL https://doi.org/10.6084/m9.figshare.3487685.v3 (Note: figshare update forthcoming and dependent on this pull request being merged).
