### PR TITLE
Add figshare link to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,12 @@ The repository contains the following directories:
 + [`download`](download) — contains files retrieved from an external location whose content is unmodified. Downloaded files are currently not tracked due to large file size, although associated metadata files are tracked for versioning.
 + [`data`](data) — contains generated datasets. The complete matrix files are not currently tracked due to file size, but randomly-subsetted versions are available for development use (see [`data/subset`](data/subset)).
 
+## Download
+
+[![DOI: 10.6084/m9.figshare.3487685](https://img.shields.io/badge/DOI-10.6084/m9.figshare.3487685-blue.svg)](https://doi.org/10.6084/m9.figshare.3487685 "Complete datasets on figshare")
+
+The complete datasets created by this repository (`data/expression-matrix.tsv.bz2` and `data/mutation-matrix.tsv.bz2`) are uploaded to [figshare](https://doi.org/10.6084/m9.figshare.3487685). Since this is a manual process, check the figshare REFERENCES section to see which commit these datasets derive from. In other words, the latest version on figshare may lag behind this repository.
+
 ## Environment
 
 This repository uses conda to manage its environment, which is named `cognoma-cancer-data`. The required packages and versions are listed in [`environment.yml`](environment.yml). If as a developer, you require an additional package, add it to `environment.yml`.


### PR DESCRIPTION
Should clear up some confusion (:

Manual upload dependency is suboptimal. In the longterm we should consider a [continuous analysis ](https://doi.org/10.1101/056473) system that could automatically upload to figshare using [their API](https://docs.figshare.com/api/).
