### PR TITLE
Extract gene information

### DIFF
--- a/5.gene-info.ipynb
+++ b/5.gene-info.ipynb
@@ -1,0 +1,506 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Export gene information"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "import collections\n",
+    "\n",
+    "import pandas"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Compute local gene information"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "path = os.path.join('data', 'mutation-matrix.tsv.bz2')\n",
+    "mutation_df = pandas.read_table(path, index_col=0)\n",
+    "\n",
+    "path = os.path.join('data', 'expression-matrix.tsv.bz2')\n",
+    "expr_df = pandas.read_table(path, index_col=0)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>entrez_gene_id</th>\n",
+       "      <th>n_mutations</th>\n",
+       "      <th>mutation_frequency</th>\n",
+       "      <th>mean_expression</th>\n",
+       "      <th>mutation</th>\n",
+       "      <th>expression</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>1.0</td>\n",
+       "      <td>30.0</td>\n",
+       "      <td>0.004106</td>\n",
+       "      <td>6.709969</td>\n",
+       "      <td>1</td>\n",
+       "      <td>1</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>2.0</td>\n",
+       "      <td>130.0</td>\n",
+       "      <td>0.017794</td>\n",
+       "      <td>13.337754</td>\n",
+       "      <td>1</td>\n",
+       "      <td>1</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "   entrez_gene_id  n_mutations  mutation_frequency  mean_expression  mutation  \\\n",
+       "0             1.0         30.0            0.004106         6.709969         1   \n",
+       "1             2.0        130.0            0.017794        13.337754         1   \n",
+       "\n",
+       "   expression  \n",
+       "0           1  \n",
+       "1           1  "
+      ]
+     },
+     "execution_count": 3,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "mutation_summary_df = pandas.DataFrame.from_items([\n",
+    "    ('entrez_gene_id', mutation_df.columns.astype(int)),\n",
+    "    ('n_mutations', mutation_df.sum(axis='rows')),\n",
+    "    ('mutation_frequency', mutation_df.mean(axis='rows')),\n",
+    "])\n",
+    "\n",
+    "expression_summary_df = pandas.DataFrame.from_items([\n",
+    "    ('entrez_gene_id', expr_df.columns.astype(int)),\n",
+    "    ('mean_expression', expr_df.mean(axis='rows')),\n",
+    "])\n",
+    "\n",
+    "summary_df = mutation_summary_df.merge(expression_summary_df, how='outer')\n",
+    "summary_df['mutation'] = summary_df.n_mutations.notnull().astype(int)\n",
+    "summary_df['expression'] = summary_df.mean_expression.notnull().astype(int)\n",
+    "summary_df.head(2)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Retrieve Entrez Gene"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>entrez_gene_id</th>\n",
+       "      <th>symbol</th>\n",
+       "      <th>description</th>\n",
+       "      <th>chromosome</th>\n",
+       "      <th>gene_type</th>\n",
+       "      <th>synonyms</th>\n",
+       "      <th>aliases</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>1</td>\n",
+       "      <td>A1BG</td>\n",
+       "      <td>alpha-1-B glycoprotein</td>\n",
+       "      <td>19</td>\n",
+       "      <td>protein-coding</td>\n",
+       "      <td>A1B|ABG|GAB|HYST2477</td>\n",
+       "      <td>alpha-1B-glycoprotein|HEL-S-163pA|epididymis s...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>2</td>\n",
+       "      <td>A2M</td>\n",
+       "      <td>alpha-2-macroglobulin</td>\n",
+       "      <td>12</td>\n",
+       "      <td>protein-coding</td>\n",
+       "      <td>A2MD|CPAMD5|FWP007|S863-7</td>\n",
+       "      <td>alpha-2-macroglobulin|C3 and PZP-like alpha-2-...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>3</td>\n",
+       "      <td>A2MP1</td>\n",
+       "      <td>alpha-2-macroglobulin pseudogene 1</td>\n",
+       "      <td>12</td>\n",
+       "      <td>pseudo</td>\n",
+       "      <td>A2MP</td>\n",
+       "      <td>pregnancy-zone protein pseudogene</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>9</td>\n",
+       "      <td>NAT1</td>\n",
+       "      <td>N-acetyltransferase 1</td>\n",
+       "      <td>8</td>\n",
+       "      <td>protein-coding</td>\n",
+       "      <td>AAC1|MNAT|NAT-1|NATI</td>\n",
+       "      <td>arylamine N-acetyltransferase 1|N-acetyltransf...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>10</td>\n",
+       "      <td>NAT2</td>\n",
+       "      <td>N-acetyltransferase 2</td>\n",
+       "      <td>8</td>\n",
+       "      <td>protein-coding</td>\n",
+       "      <td>AAC2|NAT-2|PNAT</td>\n",
+       "      <td>arylamine N-acetyltransferase 2|N-acetyltransf...</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "   entrez_gene_id symbol                         description chromosome  \\\n",
+       "0               1   A1BG              alpha-1-B glycoprotein         19   \n",
+       "1               2    A2M               alpha-2-macroglobulin         12   \n",
+       "2               3  A2MP1  alpha-2-macroglobulin pseudogene 1         12   \n",
+       "3               9   NAT1               N-acetyltransferase 1          8   \n",
+       "4              10   NAT2               N-acetyltransferase 2          8   \n",
+       "\n",
+       "        gene_type                   synonyms  \\\n",
+       "0  protein-coding       A1B|ABG|GAB|HYST2477   \n",
+       "1  protein-coding  A2MD|CPAMD5|FWP007|S863-7   \n",
+       "2          pseudo                       A2MP   \n",
+       "3  protein-coding       AAC1|MNAT|NAT-1|NATI   \n",
+       "4  protein-coding            AAC2|NAT-2|PNAT   \n",
+       "\n",
+       "                                             aliases  \n",
+       "0  alpha-1B-glycoprotein|HEL-S-163pA|epididymis s...  \n",
+       "1  alpha-2-macroglobulin|C3 and PZP-like alpha-2-...  \n",
+       "2                  pregnancy-zone protein pseudogene  \n",
+       "3  arylamine N-acetyltransferase 1|N-acetyltransf...  \n",
+       "4  arylamine N-acetyltransferase 2|N-acetyltransf...  "
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "renamer = collections.OrderedDict([\n",
+    "    ('GeneID', 'entrez_gene_id'),\n",
+    "    ('Symbol', 'symbol'),\n",
+    "    ('description', 'description'),\n",
+    "    ('chromosome', 'chromosome'),\n",
+    "    ('type_of_gene', 'gene_type'),\n",
+    "    ('Synonyms', 'synonyms'),\n",
+    "    ('Other_designations', 'aliases'),\n",
+    "])\n",
+    "\n",
+    "url = 'ftp://ftp.ncbi.nih.gov/gene/DATA/GENE_INFO/Mammalia/Homo_sapiens.gene_info.gz'\n",
+    "entrez_df = (pandas.read_table(url, compression='gzip')\n",
+    "    .rename(columns=renamer)\n",
+    "    [list(renamer.values())]\n",
+    ")\n",
+    "entrez_df.head()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Combine local information with Entrez Gene"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "22973"
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "combined_df = entrez_df.merge(summary_df, how='right').sort_values('entrez_gene_id')\n",
+    "len(combined_df)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "entrez_gene_id           0\n",
+       "symbol                  99\n",
+       "description             99\n",
+       "chromosome              99\n",
+       "gene_type               99\n",
+       "synonyms                99\n",
+       "aliases                 99\n",
+       "n_mutations           1033\n",
+       "mutation_frequency    1033\n",
+       "mean_expression       2443\n",
+       "mutation                 0\n",
+       "expression               0\n",
+       "dtype: int64"
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Missing value per column\n",
+    "combined_df.isnull().sum()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>entrez_gene_id</th>\n",
+       "      <th>symbol</th>\n",
+       "      <th>description</th>\n",
+       "      <th>chromosome</th>\n",
+       "      <th>gene_type</th>\n",
+       "      <th>synonyms</th>\n",
+       "      <th>aliases</th>\n",
+       "      <th>n_mutations</th>\n",
+       "      <th>mutation_frequency</th>\n",
+       "      <th>mean_expression</th>\n",
+       "      <th>mutation</th>\n",
+       "      <th>expression</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>1.0</td>\n",
+       "      <td>A1BG</td>\n",
+       "      <td>alpha-1-B glycoprotein</td>\n",
+       "      <td>19</td>\n",
+       "      <td>protein-coding</td>\n",
+       "      <td>A1B|ABG|GAB|HYST2477</td>\n",
+       "      <td>alpha-1B-glycoprotein|HEL-S-163pA|epididymis s...</td>\n",
+       "      <td>30.0</td>\n",
+       "      <td>0.004106</td>\n",
+       "      <td>6.709969</td>\n",
+       "      <td>1</td>\n",
+       "      <td>1</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>2.0</td>\n",
+       "      <td>A2M</td>\n",
+       "      <td>alpha-2-macroglobulin</td>\n",
+       "      <td>12</td>\n",
+       "      <td>protein-coding</td>\n",
+       "      <td>A2MD|CPAMD5|FWP007|S863-7</td>\n",
+       "      <td>alpha-2-macroglobulin|C3 and PZP-like alpha-2-...</td>\n",
+       "      <td>130.0</td>\n",
+       "      <td>0.017794</td>\n",
+       "      <td>13.337754</td>\n",
+       "      <td>1</td>\n",
+       "      <td>1</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>3.0</td>\n",
+       "      <td>A2MP1</td>\n",
+       "      <td>alpha-2-macroglobulin pseudogene 1</td>\n",
+       "      <td>12</td>\n",
+       "      <td>pseudo</td>\n",
+       "      <td>A2MP</td>\n",
+       "      <td>pregnancy-zone protein pseudogene</td>\n",
+       "      <td>4.0</td>\n",
+       "      <td>0.000547</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>1</td>\n",
+       "      <td>0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>9.0</td>\n",
+       "      <td>NAT1</td>\n",
+       "      <td>N-acetyltransferase 1</td>\n",
+       "      <td>8</td>\n",
+       "      <td>protein-coding</td>\n",
+       "      <td>AAC1|MNAT|NAT-1|NATI</td>\n",
+       "      <td>arylamine N-acetyltransferase 1|N-acetyltransf...</td>\n",
+       "      <td>17.0</td>\n",
+       "      <td>0.002327</td>\n",
+       "      <td>6.728763</td>\n",
+       "      <td>1</td>\n",
+       "      <td>1</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>10.0</td>\n",
+       "      <td>NAT2</td>\n",
+       "      <td>N-acetyltransferase 2</td>\n",
+       "      <td>8</td>\n",
+       "      <td>protein-coding</td>\n",
+       "      <td>AAC2|NAT-2|PNAT</td>\n",
+       "      <td>arylamine N-acetyltransferase 2|N-acetyltransf...</td>\n",
+       "      <td>26.0</td>\n",
+       "      <td>0.003559</td>\n",
+       "      <td>2.086277</td>\n",
+       "      <td>1</td>\n",
+       "      <td>1</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "   entrez_gene_id symbol                         description chromosome  \\\n",
+       "0             1.0   A1BG              alpha-1-B glycoprotein         19   \n",
+       "1             2.0    A2M               alpha-2-macroglobulin         12   \n",
+       "2             3.0  A2MP1  alpha-2-macroglobulin pseudogene 1         12   \n",
+       "3             9.0   NAT1               N-acetyltransferase 1          8   \n",
+       "4            10.0   NAT2               N-acetyltransferase 2          8   \n",
+       "\n",
+       "        gene_type                   synonyms  \\\n",
+       "0  protein-coding       A1B|ABG|GAB|HYST2477   \n",
+       "1  protein-coding  A2MD|CPAMD5|FWP007|S863-7   \n",
+       "2          pseudo                       A2MP   \n",
+       "3  protein-coding       AAC1|MNAT|NAT-1|NATI   \n",
+       "4  protein-coding            AAC2|NAT-2|PNAT   \n",
+       "\n",
+       "                                             aliases  n_mutations  \\\n",
+       "0  alpha-1B-glycoprotein|HEL-S-163pA|epididymis s...         30.0   \n",
+       "1  alpha-2-macroglobulin|C3 and PZP-like alpha-2-...        130.0   \n",
+       "2                  pregnancy-zone protein pseudogene          4.0   \n",
+       "3  arylamine N-acetyltransferase 1|N-acetyltransf...         17.0   \n",
+       "4  arylamine N-acetyltransferase 2|N-acetyltransf...         26.0   \n",
+       "\n",
+       "   mutation_frequency  mean_expression  mutation  expression  \n",
+       "0            0.004106         6.709969         1           1  \n",
+       "1            0.017794        13.337754         1           1  \n",
+       "2            0.000547              NaN         1           0  \n",
+       "3            0.002327         6.728763         1           1  \n",
+       "4            0.003559         2.086277         1           1  "
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "combined_df.head()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "# Write to TSV\n",
+    "path = os.path.join('data', 'genes.tsv')\n",
+    "combined_df.to_csv(path, sep='\\t', index=False, float_format='%.4g')"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python [default]",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.5.2"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 1
+}

--- a/5.gene-info.ipynb
+++ b/5.gene-info.ipynb
@@ -282,6 +282,7 @@
    ],
    "source": [
     "combined_df = entrez_df.merge(summary_df, how='right').sort_values('entrez_gene_id')\n",
+    "combined_df.entrez_gene_id = combined_df.entrez_gene_id.astype(int)\n",
     "len(combined_df)"
    ]
   },
@@ -352,7 +353,7 @@
        "  <tbody>\n",
        "    <tr>\n",
        "      <th>0</th>\n",
-       "      <td>1.0</td>\n",
+       "      <td>1</td>\n",
        "      <td>A1BG</td>\n",
        "      <td>alpha-1-B glycoprotein</td>\n",
        "      <td>19</td>\n",
@@ -367,7 +368,7 @@
        "    </tr>\n",
        "    <tr>\n",
        "      <th>1</th>\n",
-       "      <td>2.0</td>\n",
+       "      <td>2</td>\n",
        "      <td>A2M</td>\n",
        "      <td>alpha-2-macroglobulin</td>\n",
        "      <td>12</td>\n",
@@ -382,7 +383,7 @@
        "    </tr>\n",
        "    <tr>\n",
        "      <th>2</th>\n",
-       "      <td>3.0</td>\n",
+       "      <td>3</td>\n",
        "      <td>A2MP1</td>\n",
        "      <td>alpha-2-macroglobulin pseudogene 1</td>\n",
        "      <td>12</td>\n",
@@ -397,7 +398,7 @@
        "    </tr>\n",
        "    <tr>\n",
        "      <th>3</th>\n",
-       "      <td>9.0</td>\n",
+       "      <td>9</td>\n",
        "      <td>NAT1</td>\n",
        "      <td>N-acetyltransferase 1</td>\n",
        "      <td>8</td>\n",
@@ -412,7 +413,7 @@
        "    </tr>\n",
        "    <tr>\n",
        "      <th>4</th>\n",
-       "      <td>10.0</td>\n",
+       "      <td>10</td>\n",
        "      <td>NAT2</td>\n",
        "      <td>N-acetyltransferase 2</td>\n",
        "      <td>8</td>\n",
@@ -431,11 +432,11 @@
       ],
       "text/plain": [
        "   entrez_gene_id symbol                         description chromosome  \\\n",
-       "0             1.0   A1BG              alpha-1-B glycoprotein         19   \n",
-       "1             2.0    A2M               alpha-2-macroglobulin         12   \n",
-       "2             3.0  A2MP1  alpha-2-macroglobulin pseudogene 1         12   \n",
-       "3             9.0   NAT1               N-acetyltransferase 1          8   \n",
-       "4            10.0   NAT2               N-acetyltransferase 2          8   \n",
+       "0               1   A1BG              alpha-1-B glycoprotein         19   \n",
+       "1               2    A2M               alpha-2-macroglobulin         12   \n",
+       "2               3  A2MP1  alpha-2-macroglobulin pseudogene 1         12   \n",
+       "3               9   NAT1               N-acetyltransferase 1          8   \n",
+       "4              10   NAT2               N-acetyltransferase 2          8   \n",
        "\n",
        "        gene_type                   synonyms  \\\n",
        "0  protein-coding       A1B|ABG|GAB|HYST2477   \n",
@@ -483,6 +484,7 @@
   }
  ],
  "metadata": {
+  "anaconda-cloud": {},
   "kernelspec": {
    "display_name": "Python [default]",
    "language": "python",

--- a/scripts/5.gene-info.py
+++ b/scripts/5.gene-info.py
@@ -68,6 +68,7 @@ entrez_df.head()
 # In[5]:
 
 combined_df = entrez_df.merge(summary_df, how='right').sort_values('entrez_gene_id')
+combined_df.entrez_gene_id = combined_df.entrez_gene_id.astype(int)
 len(combined_df)
 
 

--- a/scripts/5.gene-info.py
+++ b/scripts/5.gene-info.py
@@ -1,0 +1,90 @@
+
+# coding: utf-8
+
+# # Export gene information
+
+# In[1]:
+
+import os
+import collections
+
+import pandas
+
+
+# ## Compute local gene information
+
+# In[2]:
+
+path = os.path.join('data', 'mutation-matrix.tsv.bz2')
+mutation_df = pandas.read_table(path, index_col=0)
+
+path = os.path.join('data', 'expression-matrix.tsv.bz2')
+expr_df = pandas.read_table(path, index_col=0)
+
+
+# In[3]:
+
+mutation_summary_df = pandas.DataFrame.from_items([
+    ('entrez_gene_id', mutation_df.columns.astype(int)),
+    ('n_mutations', mutation_df.sum(axis='rows')),
+    ('mutation_frequency', mutation_df.mean(axis='rows')),
+])
+
+expression_summary_df = pandas.DataFrame.from_items([
+    ('entrez_gene_id', expr_df.columns.astype(int)),
+    ('mean_expression', expr_df.mean(axis='rows')),
+])
+
+summary_df = mutation_summary_df.merge(expression_summary_df, how='outer')
+summary_df['mutation'] = summary_df.n_mutations.notnull().astype(int)
+summary_df['expression'] = summary_df.mean_expression.notnull().astype(int)
+summary_df.head(2)
+
+
+# ## Retrieve Entrez Gene
+
+# In[4]:
+
+renamer = collections.OrderedDict([
+    ('GeneID', 'entrez_gene_id'),
+    ('Symbol', 'symbol'),
+    ('description', 'description'),
+    ('chromosome', 'chromosome'),
+    ('type_of_gene', 'gene_type'),
+    ('Synonyms', 'synonyms'),
+    ('Other_designations', 'aliases'),
+])
+
+url = 'ftp://ftp.ncbi.nih.gov/gene/DATA/GENE_INFO/Mammalia/Homo_sapiens.gene_info.gz'
+entrez_df = (pandas.read_table(url, compression='gzip')
+    .rename(columns=renamer)
+    [list(renamer.values())]
+)
+entrez_df.head()
+
+
+# ## Combine local information with Entrez Gene
+
+# In[5]:
+
+combined_df = entrez_df.merge(summary_df, how='right').sort_values('entrez_gene_id')
+len(combined_df)
+
+
+# In[6]:
+
+# Missing value per column
+combined_df.isnull().sum()
+
+
+# In[7]:
+
+combined_df.head()
+
+
+# In[8]:
+
+# Write to TSV
+path = os.path.join('data', 'genes.tsv')
+combined_df.to_csv(path, sep='\t', index=False, float_format='%.4g')
+


### PR DESCRIPTION
Closes https://github.com/cognoma/cancer-data/issues/23

This downloads the latest Entrez Gene information from their FTP site (updated daily). Obsoleted genes have missing values for the columns from Entrez Gene. Unclear how we want to proceed wrt making the backing/django-genes and cancer-data use the same gene data.
